### PR TITLE
Type fixes

### DIFF
--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -4,6 +4,7 @@ import os
 import re
 import sys
 from pathlib import Path
+from typing import Dict, List, Union, Optional, TypeVar, Type, Set
 from dataclasses import dataclass
 
 import click
@@ -100,8 +101,8 @@ def load_descriptor(file_path: Path) -> Dict:
         with file_path.open(encoding="utf-8") as file:
             return yaml.load(file, Loader=yaml.SafeLoader)
 
-    with file_path.open(mode="rb") as file:
-        return tomli.load(file)
+    with file_path.open(mode="rb") as dfile:
+        return tomli.load(dfile)
 
 
 ###
@@ -158,9 +159,9 @@ class KeyboardLayout:
         """Import a keyboard layout to instanciate the object."""
 
         # initialize a blank layout
-        self.layers = [{}, {}, {}, {}, {}, {}]
-        self.dk_set = set()
-        self.dead_keys = {}  # dictionary subset of DEAD_KEYS
+        self.layers: Dict[Layer, Dict[str, str]] = {layer: {} for layer in Layer}
+        self.dk_set: Set[str] = set()
+        self.dead_keys: Dict[str, Dict[str, str]] = {}  # dictionary subset of DEAD_KEYS
         self.meta = CONFIG.copy()  # default parameters, hardcoded
         self.has_altgr = False
         self.has_1dk = False
@@ -380,10 +381,9 @@ class KeyboardLayout:
 
         return template
 
-    def _get_geometry(self, layers: Union[List[Layer], None] = None) -> str:
+    def _get_geometry(self, layers: Optional[List[Layer]] = None) -> List[str]:
         """`geometry` view of the requested layers."""
-        if layers is None:
-            layers = [Layer.BASE]
+        layers = layers or [Layer.BASE]
 
         rows = GEOMETRY[self.geometry].rows
         template = GEOMETRY[self.geometry].template.split("\n")[:-1]
@@ -405,17 +405,17 @@ class KeyboardLayout:
         self.meta["geometry"] = shape
 
     @property
-    def base(self) -> str:
+    def base(self) -> List[str]:
         """Base + 1dk layers."""
         return self._get_geometry([Layer.BASE, Layer.ODK])
 
     @property
-    def full(self) -> str:
+    def full(self) -> List[str]:
         """Base + AltGr layers."""
         return self._get_geometry([Layer.BASE, Layer.ALTGR])
 
     @property
-    def altgr(self) -> str:
+    def altgr(self) -> List[str]:
         """AltGr layer only."""
         return self._get_geometry([Layer.ALTGR])
 

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -247,13 +247,13 @@ class KeyboardLayout:
 
         self.dead_keys = {}
         for dk in DEAD_KEYS:
-            id = dk["char"]
+            id = dk.char
             if id not in self.dk_set:
                 continue
 
             self.dead_keys[id] = {}
             deadkey = self.dead_keys[id]
-            deadkey[id] = dk["alt_self"]
+            deadkey[id] = dk.alt_self
 
             if id == ODK_ID:
                 self.has_1dk = True
@@ -269,13 +269,13 @@ class KeyboardLayout:
                     deadkey[space] = spc["1dk"]
 
             else:
-                base = dk["base"]
-                alt = dk["alt"]
+                base = dk.base
+                alt = dk.alt
                 for i in range(len(base)):
                     if layout_has_char(base[i]):
                         deadkey[base[i]] = alt[i]
                 for space in all_spaces:
-                    deadkey[space] = dk["alt_space"]
+                    deadkey[space] = dk.alt_space
 
     def _parse_template(self, template: List[str],
                         rows: List[RowDescr], layer_number: Layer) -> None:
@@ -313,8 +313,8 @@ class KeyboardLayout:
                     self.layers[layer_number.next()][key] = shift_key
 
                 for dk in DEAD_KEYS:
-                    if base_key == dk["char"] or shift_key == dk["char"]:
-                        self.dk_set.add(dk["char"])
+                    if base_key == dk.char or shift_key == dk.char:
+                        self.dk_set.add(dk.char)
 
                 i += 6
             j += 1

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -262,7 +262,7 @@ class KeyboardLayout:
                         continue
                     for i in [Layer.ODK_SHIFT, Layer.ODK]:
                         if key_name in self.layers[i]:
-                            deadkey[self.layers[i - Layer.ODK][key_name]] = self.layers[
+                            deadkey[self.layers[i.necromance()][key_name]] = self.layers[
                                 i
                             ][key_name]
                 for space in all_spaces:
@@ -308,9 +308,9 @@ class KeyboardLayout:
                         # shift_key = base_key.upper()
 
                 if base_key != " ":
-                    self.layers[layer_number + 0][key] = base_key
+                    self.layers[layer_number][key] = base_key
                 if shift_key != " ":
-                    self.layers[layer_number + 1][key] = shift_key
+                    self.layers[layer_number.next()][key] = shift_key
 
                 for dk in DEAD_KEYS:
                     if base_key == dk["char"] or shift_key == dk["char"]:
@@ -349,8 +349,8 @@ class KeyboardLayout:
                     base_key = self.layers[layer_number][key]
 
                 shift_key = " "
-                if key in self.layers[layer_number + 1]:
-                    shift_key = self.layers[layer_number + 1][key]
+                if key in self.layers[layer_number.next()]:
+                    shift_key = self.layers[layer_number.next()][key]
 
                 dead_base = len(base_key) == 2 and base_key[0] == "*"
                 dead_shift = len(shift_key) == 2 and shift_key[0] == "*"
@@ -407,12 +407,12 @@ class KeyboardLayout:
     @property
     def base(self) -> str:
         """Base + 1dk layers."""
-        return self._get_geometry([0, Layer.ODK])
+        return self._get_geometry([Layer.BASE, Layer.ODK])
 
     @property
     def full(self) -> str:
         """Base + AltGr layers."""
-        return self._get_geometry([0, Layer.ALTGR])
+        return self._get_geometry([Layer.BASE, Layer.ALTGR])
 
     @property
     def altgr(self) -> str:

--- a/kalamine/template.py
+++ b/kalamine/template.py
@@ -436,7 +436,7 @@ def osx_actions(layout: "KeyboardLayout") -> List[str]:
                 continue
 
             key = layout.layers[i][key_name]
-            if i and key == layout.layers[0][key_name]:
+            if i and key == layout.layers[Layer.BASE][key_name]:
                 continue
             if key in layout.dead_keys:
                 continue

--- a/kalamine/template.py
+++ b/kalamine/template.py
@@ -9,7 +9,7 @@ if TYPE_CHECKING:
 
 DK_INDEX = {}
 for dk in DEAD_KEYS:
-    DK_INDEX[dk["char"]] = dk
+    DK_INDEX[dk.char] = dk
 
 
 ###
@@ -65,7 +65,7 @@ def xkb_keymap(layout: "KeyboardLayout", xkbcomp: bool = False) -> List[str]:
                 desc = keysym
                 # dead key?
                 if keysym in DK_INDEX:
-                    name = DK_INDEX[keysym]["name"]
+                    name = DK_INDEX[keysym].name
                     desc = layout.dead_keys[keysym][keysym]
                     symbol = odk_symbol if keysym == ODK_ID else f"dead_{name}"
                 # regular key: use a keysym if possible, utf-8 otherwise
@@ -296,7 +296,7 @@ def klc_deadkeys(layout: "KeyboardLayout") -> List[str]:
             continue
         dk = layout.dead_keys[k]
 
-        output.append(f"// DEADKEY: {DK_INDEX[k]['name'].upper()} //" + "{{{")
+        output.append(f"// DEADKEY: {DK_INDEX[k].name.upper()} //" + "{{{")
         output.append(f"DEADKEY\t{hex_ord(dk[' '])}")
 
         for base, alt in dk.items():
@@ -328,7 +328,7 @@ def klc_dk_index(layout: "KeyboardLayout") -> List[str]:
         if k not in layout.dead_keys:
             continue
         dk = layout.dead_keys[k]
-        output.append(f"{hex_ord(dk[' '])}\t\"{DK_INDEX[k]['name'].upper()}\"")
+        output.append(f"{hex_ord(dk[' '])}\t\"{DK_INDEX[k].name.upper()}\"")
     return output
 
 
@@ -373,7 +373,7 @@ def osx_keymap(layout: "KeyboardLayout") -> List[str]:
             if key_name in layer:
                 key = layer[key_name]
                 if key in layout.dead_keys:
-                    symbol = f"dead_{DK_INDEX[key]['name']}"
+                    symbol = f"dead_{DK_INDEX[key].name}"
                     final_key = False
                 else:
                     symbol = xml_proof(key.upper() if caps else key)
@@ -398,7 +398,7 @@ def osx_actions(layout: "KeyboardLayout") -> List[str]:
     def when(state, action):
         state_attr = f'state="{state}"'.ljust(18)
         if action in layout.dead_keys:
-            action_attr = f"next=\"{DK_INDEX[action]['name']}\""
+            action_attr = f"next=\"{DK_INDEX[action].name}\""
         elif action.startswith("dead_"):
             action_attr = f'next="{action[5:]}"'
         else:
@@ -414,12 +414,12 @@ def osx_actions(layout: "KeyboardLayout") -> List[str]:
 
     # dead key definitions
     for key in layout.dead_keys:
-        name = DK_INDEX[key]["name"]
+        name = DK_INDEX[key].name
         term = layout.dead_keys[key][key]
         ret_actions.append(f'<action id="dead_{name}">')
         ret_actions.append(f'  <when state="none" next="{name}" />')
         if name == "1dk" and term in layout.dead_keys:
-            nested_dk = DK_INDEX[term]["name"]
+            nested_dk = DK_INDEX[term].name
             ret_actions.append(f'  <when state="1dk" next="{nested_dk}" />')
         ret_actions.append("</action>")
         continue
@@ -445,7 +445,7 @@ def osx_actions(layout: "KeyboardLayout") -> List[str]:
             for k in DK_INDEX:
                 if k in layout.dead_keys:
                     if key in layout.dead_keys[k]:
-                        actions.append((DK_INDEX[k]["name"], layout.dead_keys[k][key]))
+                        actions.append((DK_INDEX[k].name, layout.dead_keys[k][key]))
             if actions:
                 append_actions(xml_proof(key), actions)
 
@@ -453,7 +453,7 @@ def osx_actions(layout: "KeyboardLayout") -> List[str]:
     actions = []
     for k in DK_INDEX:
         if k in layout.dead_keys:
-            actions.append((DK_INDEX[k]["name"], layout.dead_keys[k][" "]))
+            actions.append((DK_INDEX[k].name, layout.dead_keys[k][" "]))
     append_actions("&#x0020;", actions)  # space
     append_actions("&#x00a0;", actions)  # no-break space
     append_actions("&#x202f;", actions)  # fine no-break space
@@ -469,7 +469,7 @@ def osx_terminators(layout: "KeyboardLayout") -> List[str]:
         if key not in layout.dead_keys:
             continue
         dk = layout.dead_keys[key]
-        name = DK_INDEX[key]["name"]
+        name = DK_INDEX[key].name
         term = dk[key]
         if name == "1dk" and term in layout.dead_keys:
             term = dk[" "]

--- a/kalamine/template.py
+++ b/kalamine/template.py
@@ -49,7 +49,7 @@ def xkb_keymap(layout: "KeyboardLayout", xkbcomp: bool = False) -> List[str]:
     odk_symbol = "ISO_Level5_Latch" if eight_level else "ISO_Level3_Latch"
     max_length = 16  # `ISO_Level3_Latch` should be the longest symbol name
 
-    output = []
+    output: List[str] = []
     for key_name in LAYER_KEYS:
         if key_name.startswith("-"):  # separator
             if output:
@@ -59,7 +59,7 @@ def xkb_keymap(layout: "KeyboardLayout", xkbcomp: bool = False) -> List[str]:
 
         symbols = []
         description = " //"
-        for layer in layout.layers:
+        for layer in layout.layers.values():
             if key_name in layer:
                 keysym = layer[key_name]
                 desc = keysym
@@ -338,7 +338,7 @@ def klc_dk_index(layout: "KeyboardLayout") -> List[str]:
 #
 
 
-def osx_keymap(layout: "KeyboardLayout") -> List[str]:
+def osx_keymap(layout: "KeyboardLayout") -> List[List[str]]:
     """macOS layout, main part."""
 
     ret_str = []
@@ -356,7 +356,7 @@ def osx_keymap(layout: "KeyboardLayout") -> List[str]:
                     return True
             return False
 
-        output = []
+        output: List[str] = []
         for key_name in LAYER_KEYS:
             if key_name in ["ae13", "ab11"]:  # ABNT / JIS keys
                 continue  # these two keys are not supported yet

--- a/kalamine/utils.py
+++ b/kalamine/utils.py
@@ -1,4 +1,5 @@
 #!/usr/bin/env python3
+from dataclasses import dataclass
 import os
 from enum import IntEnum
 from pathlib import Path
@@ -53,6 +54,19 @@ class Layer(IntEnum):
         elif self == Layer.ODK_SHIFT:
             return Layer.SHIFT
         return self
+
+@dataclass
+class DeadKeyDescr:
+    char: str
+    name: str
+    base: str
+    alt: str
+    alt_space: str
+    alt_self: str
+
+
+DEAD_KEYS = [DeadKeyDescr(**data) for data in load_data( "dead_keys.yaml")]
+
 ODK_ID = "**"  # must match the value in dead_keys.yaml
 LAYER_KEYS = [
     "- Digits",

--- a/kalamine/utils.py
+++ b/kalamine/utils.py
@@ -42,8 +42,17 @@ class Layer(IntEnum):
     ALTGR = 4
     ALTGR_SHIFT = 5
 
+    def next(self) -> 'Layer':
+        """The next layer in the layer ordering."""
+        return Layer(int(self)+1)
 
-DEAD_KEYS = load_data("dead_keys.yaml")
+    def necromance(self) -> 'Layer':
+        """Remove the effect of the dead key if any."""
+        if self == Layer.ODK:
+            return Layer.BASE
+        elif self == Layer.ODK_SHIFT:
+            return Layer.SHIFT
+        return self
 ODK_ID = "**"  # must match the value in dead_keys.yaml
 LAYER_KEYS = [
     "- Digits",

--- a/kalamine/utils.py
+++ b/kalamine/utils.py
@@ -7,7 +7,13 @@ from typing import Dict, List
 import yaml
 
 
-def lines_to_text(lines: List[str], indent: str = ""):
+def lines_to_text(lines: List[str], indent: str = "") -> str:
+    """
+    From a list lines of string, produce a string concatenating the elements
+    of lines indented by prepending indent and followed by a new line.
+    Example: lines_to_text(["one", "two", "three"], "  ") returns
+    '  one\n  two\n  three'
+    """
     out = ""
     for line in lines:
         if len(line):
@@ -17,6 +23,7 @@ def lines_to_text(lines: List[str], indent: str = ""):
 
 
 def text_to_lines(text: str) -> List[str]:
+    """Split given text into lines"""
     return text.split("\n")
 
 


### PR DESCRIPTION
Assorted type annotations fixes. In order to work reliably, type annotations need to get rid of all the "dictionary bags". So this PR also introduces more structured data types for `DEAD_KEYS` and `GEOMETRY`. It also reduces the number of abuse of the fact that `Layer` objects are secretly `int`.

Note: I tried to produce reviewable individual commits, but this required some history rewriting because I was not rigorous enough when editing. It should be mostly ok except for a couple of phantom line deletions that should be ignored in early commits.