### PR TITLE
SVG view improvements 

### DIFF
--- a/kalamine/cli.py
+++ b/kalamine/cli.py
@@ -12,8 +12,7 @@ from .server import keyboard_server
 
 
 @click.group()
-def cli() -> None:
-    ...
+def cli() -> None: ...
 
 
 def pretty_json(layout: KeyboardLayout, output_path: Path) -> None:
@@ -134,9 +133,7 @@ def make(layout_descriptors: List[Path], out: Union[Path, Literal["all"]]):
                 file.write(layout.klc)
 
         elif output_file.suffix == ".keylayout":
-            with output_file.open(
-                "w", encoding="utf-8", newline="\n"
-            ) as file:
+            with output_file.open("w", encoding="utf-8", newline="\n") as file:
                 file.write(layout.keylayout)
 
         elif output_file.suffix == ".xkb":
@@ -144,9 +141,7 @@ def make(layout_descriptors: List[Path], out: Union[Path, Literal["all"]]):
                 file.write(layout.xkb)
 
         elif output_file.suffix == ".xkb_custom":
-            with output_file.open(
-                 "w", encoding="utf-8", newline="\n"
-            ) as file:
+            with output_file.open("w", encoding="utf-8", newline="\n") as file:
                 file.write(layout.xkb_patch)
 
         elif output_file.suffix == ".json":

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -478,22 +478,22 @@ class KeyboardLayout:
         deadkeys = web_deadkeys(self)
         # breakpoint()
 
-        def print_char(location, char :str):
+        def set_key_label(label_element, char :str):
             if char not in deadkeys:
-                location.text = char
+                label_element.text = char
             else:
-                location.text = "★" if char == "**" else char[-1] # only last char for deadkeys
+                label_element.text = "★" if char == "**" else char[-1] # only last char for deadkeys
                 # Apply special class for deadkeys
-                location.set(
-                    "class", location.get("class") + " deadKey diacritic"
+                label_element.set(
+                    "class", label_element.get("class") + " deadKey diacritic"
                 )
 
         # Fill-in with layout
         for name, chars in keymap.items():
             for key in svg.xpath(f'//svg:g[@id="{name}"]', namespaces=ns):
                 # Print 1-4 level chars
-                for level_num, char in enumerate(chars, start=1):
-                    if chars[0] == chars[1].lower() and level_num == 1:
+                for level_num, char in enumerate(chars, start=Layer.BASE):
+                    if level_num == Layer.BASE and chars[0] == chars[1].lower():
                         # Do not print letters twice (lower and upper)
                         continue
 
@@ -501,16 +501,16 @@ class KeyboardLayout:
                     for location in key.xpath(
                         f"svg:g/svg:text[@class='level{level_num}']", namespaces=ns
                     ):
-                        print_char(location, char)
+                        set_key_label(location, char)
 
                 # Print 5-6 levels (1dk deadkeys)
                 if deadkeys and (main_deadkey := deadkeys.get("**")):
-                    for level_num, char in enumerate(chars[:2], start=5):
+                    for level_num, char in enumerate(chars[:2], start=Layer.ODK):
                         dead_char = main_deadkey.get(char)
-                        if level_num == 6:
+                        if level_num == Layer.ODK_SHIFT:
+                            # Do not print letters twice (lower and upper)
                             if dead_char_previous := main_deadkey.get(chars[0]):
                                 if upper_key(dead_char_previous) == dead_char:
-                                    # Do not print letters twice (lower and upper)
                                     continue
 
                         if dead_char:
@@ -518,6 +518,6 @@ class KeyboardLayout:
                                 f"svg:g/svg:text[@class='level{level_num} dk']",
                                 namespaces=ns,
                             ):
-                                print_char(location, dead_char)
+                                set_key_label(location, dead_char)
 
         return svg

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -24,8 +24,15 @@ from .template import (
     web_keymap,
     xkb_keymap,
 )
-from .utils import DEAD_KEYS, LAYER_KEYS, ODK_ID, Layer, lines_to_text, load_data, text_to_lines
-
+from .utils import (
+    DEAD_KEYS,
+    LAYER_KEYS,
+    ODK_ID,
+    Layer,
+    lines_to_text,
+    load_data,
+    text_to_lines,
+)
 
 ###
 # Helpers
@@ -478,11 +485,13 @@ class KeyboardLayout:
         deadkeys = web_deadkeys(self)
         # breakpoint()
 
-        def set_key_label(label_element, char :str):
+        def set_key_label(label_element, char: str):
             if char not in deadkeys:
                 label_element.text = char
             else:
-                label_element.text = "★" if char == "**" else char[-1] # only last char for deadkeys
+                label_element.text = (
+                    "★" if char == "**" else char[-1]
+                )  # only last char for deadkeys
                 # Apply special class for deadkeys
                 label_element.set(
                     "class", label_element.get("class") + " deadKey diacritic"
@@ -496,7 +505,6 @@ class KeyboardLayout:
                     if level_num == Layer.BASE and chars[0] == chars[1].lower():
                         # Do not print letters twice (lower and upper)
                         continue
-
 
                     for location in key.xpath(
                         f"svg:g/svg:text[@class='level{level_num}']", namespaces=ns

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -486,13 +486,14 @@ class KeyboardLayout:
                         # Do not print letters twice (lower and upper)
                         continue
 
+
                     for location in key.xpath(
                         f"svg:g/svg:text[@class='level{level_num}']", namespaces=ns
                     ):
                         if char not in deadkeys:
                             location.text = char
                         else:
-                            location.text = "★" if char == "**" else char[1:]
+                            location.text = "★" if char == "**" else char[-1] # only last char for deadkeys
                             # Apply special class for deadkeys
                             location.set(
                                 "class", location.get("class") + " deadKey diacritic"
@@ -501,7 +502,14 @@ class KeyboardLayout:
                 # Print 5-6 levels (1dk deadkeys)
                 if deadkeys and (main_deadkey := deadkeys.get("**")):
                     for level_num, char in enumerate(chars[:2], start=5):
-                        if dead_char := main_deadkey.get(char):
+                        dead_char = main_deadkey.get(char)
+                        if level_num == 6:
+                            if dead_char_previous := main_deadkey.get(chars[0]):
+                                if upper_key(dead_char_previous) == dead_char:
+                                    # Do not print letters twice (lower and upper)
+                                    continue
+
+                        if dead_char:
                             for location in key.xpath(
                                 f"svg:g/svg:text[@class='level{level_num} dk']",
                                 namespaces=ns,

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -477,6 +477,17 @@ class KeyboardLayout:
         keymap = web_keymap(self)
         deadkeys = web_deadkeys(self)
         # breakpoint()
+
+        def print_char(location, char :str):
+            if char not in deadkeys:
+                location.text = char
+            else:
+                location.text = "★" if char == "**" else char[-1] # only last char for deadkeys
+                # Apply special class for deadkeys
+                location.set(
+                    "class", location.get("class") + " deadKey diacritic"
+                )
+
         # Fill-in with layout
         for name, chars in keymap.items():
             for key in svg.xpath(f'//svg:g[@id="{name}"]', namespaces=ns):
@@ -490,14 +501,7 @@ class KeyboardLayout:
                     for location in key.xpath(
                         f"svg:g/svg:text[@class='level{level_num}']", namespaces=ns
                     ):
-                        if char not in deadkeys:
-                            location.text = char
-                        else:
-                            location.text = "★" if char == "**" else char[-1] # only last char for deadkeys
-                            # Apply special class for deadkeys
-                            location.set(
-                                "class", location.get("class") + " deadKey diacritic"
-                            )
+                        print_char(location, char)
 
                 # Print 5-6 levels (1dk deadkeys)
                 if deadkeys and (main_deadkey := deadkeys.get("**")):
@@ -514,6 +518,6 @@ class KeyboardLayout:
                                 f"svg:g/svg:text[@class='level{level_num} dk']",
                                 namespaces=ns,
                             ):
-                                location.text = dead_char
+                                print_char(location, dead_char)
 
         return svg

--- a/kalamine/tpl/x-keyboard.svg
+++ b/kalamine/tpl/x-keyboard.svg
@@ -315,6 +315,10 @@
     /* Translate level5 upward if mixed */
     .mixed .level5 {transform: translate(0px, -22.8px);}
 
+    /* Adding Base class option to display Alpha + dk layers */
+    .base .level3, .base .level4 { display: none;}
+    .base .level5  { opacity: 0.5; display: block;}
+
     @media (prefers-color-scheme: dark) {
       rect, path { stroke: #777; fill: #444; }
       .specialKey, .specialKey rect, .specialKey path { fill: #333; }

--- a/tests/util.py
+++ b/tests/util.py
@@ -1,4 +1,5 @@
 """Some util functions for tests."""
+
 from pathlib import Path
 
 


### PR DESCRIPTION
Improving svg classical deadkeys: removing `*` prefix and setting they in red.
Adding a `base` class on css to dispaly Alpha keys and deadkey layer. 