### PR TITLE
fix(ahk): support for capslock key

### DIFF
--- a/kalamine/tpl/base.ahk
+++ b/kalamine/tpl/base.ahk
@@ -61,13 +61,17 @@ SetTimer, ShowTrayTip, -1000  ; not working
 
 global DeadKey := ""
 
-UnicodeUpperIfCapsLock(unicode:="") {
-  CapsLockOn := GetKeyState("CapsLock", "T") 
-  if %CapsLockOn% {
-    unicode := Chr("0x" SubStr(unicode, 3, 4))
+; Check CapsLock status, upper the char if needed and send the char
+SendChar(unicode) {
+  if % GetKeyState("CapsLock", "T") {
+    if (StrLen(unicode) == 6) {
+      ; we have something in the form of `U+NNNN `
+      ; Change it to 0xNNNN so it can be passed to `Chr` function
+      unicode := Chr("0x" SubStr(unicode, 3, 4))
+    }
     StringUpper, unicode, unicode
   }
-  return unicode
+  Send, {%unicode%}
 }
 
 DoTerm(base:="") {
@@ -75,10 +79,8 @@ DoTerm(base:="") {
 
   term := SubStr(DeadKey, 2, 1)
 
-  base := UnicodeUpperIfCapsLock(base)
-
   Send, {%term%}
-  Send, {%base%}
+  SendChar(base)
   DeadKey := ""
 }
 

--- a/kalamine/tpl/base.ahk
+++ b/kalamine/tpl/base.ahk
@@ -62,16 +62,16 @@ SetTimer, ShowTrayTip, -1000  ; not working
 global DeadKey := ""
 
 ; Check CapsLock status, upper the char if needed and send the char
-SendChar(unicode) {
+SendChar(char) {
   if % GetKeyState("CapsLock", "T") {
-    if (StrLen(unicode) == 6) {
+    if (StrLen(char) == 6) {
       ; we have something in the form of `U+NNNN `
       ; Change it to 0xNNNN so it can be passed to `Chr` function
-      unicode := Chr("0x" SubStr(unicode, 3, 4))
+      char := Chr("0x" SubStr(char, 3, 4))
     }
-    StringUpper, unicode, unicode
+    StringUpper, char, char
   }
-  Send, {%unicode%}
+  Send, {%char%}
 }
 
 DoTerm(base:="") {
@@ -92,9 +92,7 @@ DoAction(action:="") {
     DeadKey := ""
   }
   else if (StrLen(action) != 2) {
-    action := UnicodeUpperIfCapsLock(action)
-    
-    Send, {%action%}
+    SendChar(action)
     DeadKey := ""
   }
   else if (action == DeadKey) {

--- a/kalamine/tpl/base.ahk
+++ b/kalamine/tpl/base.ahk
@@ -61,10 +61,23 @@ SetTimer, ShowTrayTip, -1000  ; not working
 
 global DeadKey := ""
 
+UnicodeUpper(unicode:="") {
+  unicode := Chr("0x" SubStr(unicode, 3, 4))
+  StringUpper, unicode, unicode
+  return unicode
+}
+
 DoTerm(base:="") {
   global DeadKey
 
   term := SubStr(DeadKey, 2, 1)
+
+  CapsLockOn := GetKeyState("CapsLock", "T") 
+  if %CapsLockOn% {
+    term := UnicodeUpper(term)
+    base := UnicodeUpper(base)
+  }
+
   Send, {%term%}
   Send, {%base%}
   DeadKey := ""
@@ -78,6 +91,11 @@ DoAction(action:="") {
     DeadKey := ""
   }
   else if (StrLen(action) != 2) {
+    CapsLockOn := GetKeyState("CapsLock", "T") 
+    if %CapsLockOn% {
+      action := UnicodeUpper(action)
+    }
+    
     Send, {%action%}
     DeadKey := ""
   }

--- a/kalamine/tpl/base.ahk
+++ b/kalamine/tpl/base.ahk
@@ -61,9 +61,12 @@ SetTimer, ShowTrayTip, -1000  ; not working
 
 global DeadKey := ""
 
-UnicodeUpper(unicode:="") {
-  unicode := Chr("0x" SubStr(unicode, 3, 4))
-  StringUpper, unicode, unicode
+UnicodeUpperIfCapsLock(unicode:="") {
+  CapsLockOn := GetKeyState("CapsLock", "T") 
+  if %CapsLockOn% {
+    unicode := Chr("0x" SubStr(unicode, 3, 4))
+    StringUpper, unicode, unicode
+  }
   return unicode
 }
 
@@ -72,11 +75,7 @@ DoTerm(base:="") {
 
   term := SubStr(DeadKey, 2, 1)
 
-  CapsLockOn := GetKeyState("CapsLock", "T") 
-  if %CapsLockOn% {
-    term := UnicodeUpper(term)
-    base := UnicodeUpper(base)
-  }
+  base := UnicodeUpperIfCapsLock(base)
 
   Send, {%term%}
   Send, {%base%}
@@ -91,10 +90,7 @@ DoAction(action:="") {
     DeadKey := ""
   }
   else if (StrLen(action) != 2) {
-    CapsLockOn := GetKeyState("CapsLock", "T") 
-    if %CapsLockOn% {
-      action := UnicodeUpper(action)
-    }
+    action := UnicodeUpperIfCapsLock(action)
     
     Send, {%action%}
     DeadKey := ""

--- a/kalamine/tpl/full.ahk
+++ b/kalamine/tpl/full.ahk
@@ -57,13 +57,17 @@ SetTimer, ShowTrayTip, -1000  ; not working
 
 global DeadKey := ""
 
-UnicodeUpperIfCapsLock(unicode:="") {
-  CapsLockOn := GetKeyState("CapsLock", "T") 
-  if %CapsLockOn% {
-    unicode := Chr("0x" SubStr(unicode, 3, 4))
+; Check CapsLock status, upper the char if needed and send the char
+SendChar(unicode) {
+  if % GetKeyState("CapsLock", "T") {
+    if (StrLen(unicode) == 6) {
+      ; we have something in the form of `U+NNNN `
+      ; Change it to 0xNNNN so it can be passed to `Chr` function
+      unicode := Chr("0x" SubStr(unicode, 3, 4))
+    }
     StringUpper, unicode, unicode
   }
-  return unicode
+  Send, {%unicode%}
 }
 
 DoTerm(base:="") {
@@ -71,10 +75,8 @@ DoTerm(base:="") {
 
   term := SubStr(DeadKey, 2, 1)
 
-  base := UnicodeUpperIfCapsLock(base)
-
   Send, {%term%}
-  Send, {%base%}
+  SendChar(base)
   DeadKey := ""
 }
 
@@ -86,9 +88,7 @@ DoAction(action:="") {
     DeadKey := ""
   }
   else if (StrLen(action) != 2) {
-    action := UnicodeUpperIfCapsLock(action)
-    
-    Send, {%action%}
+    SendChar(action)
     DeadKey := ""
   }
   else if (action == DeadKey) {

--- a/kalamine/tpl/full.ahk
+++ b/kalamine/tpl/full.ahk
@@ -57,10 +57,23 @@ SetTimer, ShowTrayTip, -1000  ; not working
 
 global DeadKey := ""
 
+UnicodeUpper(unicode:="") {
+  unicode := Chr("0x" SubStr(unicode, 3, 4))
+  StringUpper, unicode, unicode
+  return unicode
+}
+
 DoTerm(base:="") {
   global DeadKey
 
   term := SubStr(DeadKey, 2, 1)
+
+  CapsLockOn := GetKeyState("CapsLock", "T") 
+  if %CapsLockOn% {
+    term := UnicodeUpper(term)
+    base := UnicodeUpper(base)
+  }
+
   Send, {%term%}
   Send, {%base%}
   DeadKey := ""
@@ -74,6 +87,11 @@ DoAction(action:="") {
     DeadKey := ""
   }
   else if (StrLen(action) != 2) {
+    CapsLockOn := GetKeyState("CapsLock", "T") 
+    if %CapsLockOn% {
+      action := UnicodeUpper(action)
+    }
+    
     Send, {%action%}
     DeadKey := ""
   }

--- a/kalamine/tpl/full.ahk
+++ b/kalamine/tpl/full.ahk
@@ -57,9 +57,12 @@ SetTimer, ShowTrayTip, -1000  ; not working
 
 global DeadKey := ""
 
-UnicodeUpper(unicode:="") {
-  unicode := Chr("0x" SubStr(unicode, 3, 4))
-  StringUpper, unicode, unicode
+UnicodeUpperIfCapsLock(unicode:="") {
+  CapsLockOn := GetKeyState("CapsLock", "T") 
+  if %CapsLockOn% {
+    unicode := Chr("0x" SubStr(unicode, 3, 4))
+    StringUpper, unicode, unicode
+  }
   return unicode
 }
 
@@ -68,11 +71,7 @@ DoTerm(base:="") {
 
   term := SubStr(DeadKey, 2, 1)
 
-  CapsLockOn := GetKeyState("CapsLock", "T") 
-  if %CapsLockOn% {
-    term := UnicodeUpper(term)
-    base := UnicodeUpper(base)
-  }
+  base := UnicodeUpperIfCapsLock(base)
 
   Send, {%term%}
   Send, {%base%}
@@ -87,10 +86,7 @@ DoAction(action:="") {
     DeadKey := ""
   }
   else if (StrLen(action) != 2) {
-    CapsLockOn := GetKeyState("CapsLock", "T") 
-    if %CapsLockOn% {
-      action := UnicodeUpper(action)
-    }
+    action := UnicodeUpperIfCapsLock(action)
     
     Send, {%action%}
     DeadKey := ""

--- a/kalamine/tpl/full.ahk
+++ b/kalamine/tpl/full.ahk
@@ -58,16 +58,16 @@ SetTimer, ShowTrayTip, -1000  ; not working
 global DeadKey := ""
 
 ; Check CapsLock status, upper the char if needed and send the char
-SendChar(unicode) {
+SendChar(char) {
   if % GetKeyState("CapsLock", "T") {
-    if (StrLen(unicode) == 6) {
+    if (StrLen(char) == 6) {
       ; we have something in the form of `U+NNNN `
       ; Change it to 0xNNNN so it can be passed to `Chr` function
-      unicode := Chr("0x" SubStr(unicode, 3, 4))
+      char := Chr("0x" SubStr(char, 3, 4))
     }
-    StringUpper, unicode, unicode
+    StringUpper, char, char
   }
-  Send, {%unicode%}
+  Send, {%char%}
 }
 
 DoTerm(base:="") {


### PR DESCRIPTION
It works when an obvious upper case is found, so it will not work for the num row  and other symbols