### PR TITLE
bugfix: `kalamine watch`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -141,7 +141,6 @@ Basic developer info available in Kalamine’s `KLC documentation page`_.
 .. _`KLC documentation page`: https://github.com/OneDeadKey/kalamine/tree/master/docs/klc.md
 
 
-
 macOS: ``*.keylayout``
 ``````````````````````
 

--- a/README.rst
+++ b/README.rst
@@ -134,7 +134,7 @@ The keyboard layout appears in the language bar.
 
 Note: in some cases, custom dead keys may not be supported any more by MSKLC on Windows 10/11. KbdEdit works fine.
 
-Basic developer info available in Kalamine’s _`KLC documentation page`.
+Basic developer info available in Kalamine’s `KLC documentation page`_.
 
 .. _MSKLC: https://www.microsoft.com/en-us/download/details.aspx?id=102134
 .. _KbdEdit: http://www.kbdedit.com/

--- a/kalamine/server.py
+++ b/kalamine/server.py
@@ -88,7 +88,7 @@ def keyboard_server(file_path: Path) -> None:
             elif self.path == "/xkb_custom":
                 send(kb_layout.xkb_patch)
             elif self.path == "/":
-                kb_layout = KeyboardLayout(file_path)  # refresh
+                kb_layout = KeyboardLayout(load_layout(file_path))  # refresh
                 send(main_page(kb_layout), content="text/html")
             else:
                 return SimpleHTTPRequestHandler.do_GET(self)

--- a/kalamine/server.py
+++ b/kalamine/server.py
@@ -105,7 +105,7 @@ def keyboard_server(file_path: Path) -> None:
 
         # livereload
         lr_server = Server()
-        lr_server.watch(file_path)
+        lr_server.watch(str(file_path))
         lr_server.serve(host=host_name, port=lr_server_port)
 
     except KeyboardInterrupt:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ include = [ "/docs", "/kalamine", "/layouts" ]
 
 [project]
 name = "kalamine"
-version = "0.27"
+version = "0.28"
 description = "a cross-platform Keyboard Layout Maker"
 readme = "README.rst"
 


### PR DESCRIPTION
Fixes an old regression caused by the switch from `os.path` to `pathlib` here: https://github.com/OneDeadKey/kalamine/commit/3da728f63a9d1b2bcd37919de1076146b25da0b3

And fixes a very recent regression caused by the switch from `pathlib` to `pkgutil` in #99.