### PR TITLE
[xkb] `*.xkb_keymap` and `*.kkb_symbols` outputs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -51,8 +51,8 @@ jobs:
 
       - name: Run tests
         run: |
-          python -m kalamine.cli make layouts/*.toml
-          python -m kalamine.cli create test.toml
+          python -m kalamine.cli build layouts/*.toml
+          python -m kalamine.cli new test.toml
           pytest
       - name: Run black
         run: black kalamine

--- a/Makefile
+++ b/Makefile
@@ -19,7 +19,7 @@ lint:  ## Lint sources
 
 test:  ## Run tests
 	python3 -m kalamine.cli guide > docs/README.md
-	python3 -m kalamine.cli make layouts/*.toml
+	python3 -m kalamine.cli build layouts/*.toml
 	pytest
 
 publish: test  ## Publish package

--- a/docs/xkb.md
+++ b/docs/xkb.md
@@ -1,0 +1,21 @@
+XKB Considerations
+================================================================================
+
+> If you want custom keymaps on your machine, switch to Wayland (and/or fix any
+> remaining issues preventing you from doing so) instead of hoping this will
+> ever work on X.
+
+— [Peter Hutterer](https://who-t.blogspot.com/2020/09/no-user-specific-xkb-configuration-in-x.html)
+
+
+
+Resources
+--------------------------------------------------------------------------------
+
+XKB is a tricky piece of software.
+The following resources might be helpful if you want to dig in:
+
+- https://www.charvolant.org/doug/xkb/html/
+- https://wiki.archlinux.org/title/X_keyboard_extension
+- https://wiki.archlinux.org/title/Xorg/Keyboard_configuration
+- https://github.com/xkbcommon/libxkbcommon/blob/master/doc/keymap-format-text-v1.md

--- a/kalamine/cli_xkb.py
+++ b/kalamine/cli_xkb.py
@@ -38,9 +38,9 @@ def apply(filepath: Path, angle_mod: bool) -> None:
 
     layout = KeyboardLayout(load_layout(filepath), angle_mod)
     with tempfile.NamedTemporaryFile(
-        mode="w+", suffix=".xkb", encoding="utf-8"
+        mode="w+", suffix=".xkb_keymap", encoding="utf-8"
     ) as temp_file:
-        temp_file.write(layout.xkb)
+        temp_file.write(layout.xkb_keymap)
         os.system(f"xkbcomp -w0 {temp_file.name} $DISPLAY")
 
 

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -535,16 +535,16 @@ class KeyboardLayout:
         return out
 
     @property
-    def xkb(self) -> str:  # will not work with Wayland
+    def xkb_keymap(self) -> str:  # will not work with Wayland
         """GNU/Linux driver (standalone / user-space)"""
-        out = load_tpl(self, ".xkb")
+        out = load_tpl(self, ".xkb_keymap")
         out = substitute_lines(out, "LAYOUT", xkb_keymap(self, xkbcomp=True))
         return out
 
     @property
-    def xkb_patch(self) -> str:
+    def xkb_symbols(self) -> str:
         """GNU/Linux driver (xkb patch, system or user-space)"""
-        out = load_tpl(self, ".xkb_patch")
+        out = load_tpl(self, ".xkb_symbols")
         out = substitute_lines(out, "LAYOUT", xkb_keymap(self, xkbcomp=False))
         return out
 

--- a/kalamine/server.py
+++ b/kalamine/server.py
@@ -50,8 +50,8 @@ def keyboard_server(file_path: Path) -> None:
                     <a href="/json">json</a>
                     | <a href="/keylayout">keylayout</a>
                     | <a href="/klc">klc</a>
-                    | <a href="/xkb">xkb</a>
-                    | <a href="/xkb_custom">xkb_custom</a>
+                    | <a href="/xkb_keymap">xkb_keymap</a>
+                    | <a href="/xkb_symbols">xkb_symbols</a>
                 </p>
             </body>
             </html>
@@ -82,10 +82,10 @@ def keyboard_server(file_path: Path) -> None:
                 send(kb_layout.keylayout)
             elif self.path == "/klc":
                 send(kb_layout.klc, charset="utf-16-le")
-            elif self.path == "/xkb":
-                send(kb_layout.xkb)
-            elif self.path == "/xkb_custom":
-                send(kb_layout.xkb_patch)
+            elif self.path == "/xkb_keymap":
+                send(kb_layout.xkb_keymap)
+            elif self.path == "/xkb_symbols":
+                send(kb_layout.xkb_symbols)
             elif self.path == "/":
                 kb_layout = KeyboardLayout(load_layout(file_path))  # refresh
                 send(main_page(kb_layout), content="text/html")

--- a/kalamine/tpl/base.xkb_keymap
+++ b/kalamine/tpl/base.xkb_keymap
@@ -1,6 +1,11 @@
 // ${KALAMINE}
 //
-// File          : ${fileName}.xkb
+// This is a standalone XKB keymap file. To apply this keymap, use:
+//   xkbcomp -w9 ${fileName}.xkb_keymap $DISPLAY
+//
+// DO NOT COPY THIS INTO xkb/symbols: THIS WOULD MESS UP YOUR XKB CONFIG.
+//
+// File          : ${fileName}.xkb_keymap
 // Project page  : ${url}
 // Author        : ${author}
 // Version       : ${version}
@@ -8,22 +13,18 @@
 //
 // ${description}
 //
-// To apply this keymap, use:
-//   xkbcomp -w9 ${fileName}.xkb $DISPLAY
-//
 
 xkb_keymap {
   xkb_keycodes      { include "evdev"    };
   xkb_types         { include "complete" };
   xkb_compatibility { include "complete" };
 
-  // KALAMINE::GEOMETRY_full
+  // KALAMINE::GEOMETRY_base
 
   partial alphanumeric_keys modifier_keys
   xkb_symbols "${variant}" {
     include "pc"
     include "inet(evdev)"
-    include "level3(ralt_switch)"
 
     name[group1]= "${description}";
     key.type[group1] = "FOUR_LEVEL";

--- a/kalamine/tpl/base.xkb_symbols
+++ b/kalamine/tpl/base.xkb_symbols
@@ -1,5 +1,11 @@
 // ${KALAMINE}
 //
+//# This XKB symbols file should be copied to:
+//#     /usr/share/X11/xkb/symbols/custom
+//# or
+//#     $XKB_CONFIG_ROOT/xkb/symbols/custom
+//#
+//# File          : ${fileName}.xkb_symbols
 // Project page  : ${url}
 // Author        : ${author}
 // Version       : ${version}
@@ -7,7 +13,7 @@
 //
 // ${description}
 //
-// KALAMINE::GEOMETRY_full
+// KALAMINE::GEOMETRY_base
 
 partial alphanumeric_keys modifier_keys
 xkb_symbols "${variant}" {
@@ -15,6 +21,5 @@ xkb_symbols "${variant}" {
     key.type[group1] = "FOUR_LEVEL";
 
     KALAMINE::LAYOUT
-
-    include "level3(ralt_switch)"
 };
+//# vim: ft=xkb:fdm=indent:ts=4:nowrap

--- a/kalamine/tpl/full.xkb_keymap
+++ b/kalamine/tpl/full.xkb_keymap
@@ -1,6 +1,11 @@
 // ${KALAMINE}
 //
-// File          : ${fileName}.xkb
+// This is a standalone XKB keymap file. To apply this keymap, use:
+//   xkbcomp -w9 ${fileName}.xkb_keymap $DISPLAY
+//
+// DO NOT COPY THIS INTO xkb/symbols: THIS WOULD MESS UP YOUR XKB CONFIG.
+//
+// File          : ${fileName}.xkb_keymap
 // Project page  : ${url}
 // Author        : ${author}
 // Version       : ${version}
@@ -8,21 +13,19 @@
 //
 // ${description}
 //
-// To apply this keymap, use:
-//   xkbcomp -w9 ${fileName}.xkb $DISPLAY
-//
 
 xkb_keymap {
   xkb_keycodes      { include "evdev"    };
   xkb_types         { include "complete" };
   xkb_compatibility { include "complete" };
 
-  // KALAMINE::GEOMETRY_base
+  // KALAMINE::GEOMETRY_full
 
   partial alphanumeric_keys modifier_keys
   xkb_symbols "${variant}" {
     include "pc"
     include "inet(evdev)"
+    include "level3(ralt_switch)"
 
     name[group1]= "${description}";
     key.type[group1] = "FOUR_LEVEL";

--- a/kalamine/tpl/full.xkb_symbols
+++ b/kalamine/tpl/full.xkb_symbols
@@ -1,5 +1,11 @@
 // ${KALAMINE}
 //
+//# This XKB symbols file should be copied to:
+//#     /usr/share/X11/xkb/symbols/custom
+//# or
+//#     $XKB_CONFIG_ROOT/xkb}/symbols/custom
+//#
+//# File          : ${fileName}.xkb_symbols
 // Project page  : ${url}
 // Author        : ${author}
 // Version       : ${version}
@@ -7,7 +13,7 @@
 //
 // ${description}
 //
-// KALAMINE::GEOMETRY_base
+// KALAMINE::GEOMETRY_full
 
 partial alphanumeric_keys modifier_keys
 xkb_symbols "${variant}" {
@@ -15,4 +21,7 @@ xkb_symbols "${variant}" {
     key.type[group1] = "FOUR_LEVEL";
 
     KALAMINE::LAYOUT
+
+    include "level3(ralt_switch)"
 };
+//# vim: ft=xkb:fdm=indent:ts=4:nowrap

--- a/kalamine/tpl/full_1dk.xkb_keymap
+++ b/kalamine/tpl/full_1dk.xkb_keymap
@@ -1,15 +1,17 @@
 // ${KALAMINE}
 //
-// File          : ${fileName}.xkb
+// This is a standalone XKB keymap file. To apply this keymap, use:
+//   xkbcomp -w9 ${fileName}.xkb_keymap $DISPLAY
+//
+// DO NOT COPY THIS INTO xkb/symbols: THIS WOULD MESS UP YOUR XKB CONFIG.
+//
+// File          : ${fileName}.xkb_keymap
 // Project page  : ${url}
 // Author        : ${author}
 // Version       : ${version}
 // License       : ${license}
 //
 // ${description}
-//
-// To apply this keymap, use:
-//   xkbcomp -w9 ${fileName}.xkb $DISPLAY
 //
 
 xkb_keymap {

--- a/kalamine/tpl/full_1dk.xkb_symbols
+++ b/kalamine/tpl/full_1dk.xkb_symbols
@@ -1,5 +1,11 @@
 // ${KALAMINE}
 //
+//# This XKB symbols file should be copied to:
+//#     /usr/share/X11/xkb/symbols/custom
+//# or
+//#     $XKB_CONFIG_ROOT/xkb/symbols/custom
+//#
+//# File          : ${fileName}.xkb_symbols
 // Project page  : ${url}
 // Author        : ${author}
 // Version       : ${version}
@@ -31,3 +37,4 @@ xkb_symbols "${variant}" {
     };
     modifier_map Mod3 { <MDSW> };
 };
+//# vim: ft=xkb:fdm=indent:ts=4:nowrap

--- a/kalamine/xkb_manager.py
+++ b/kalamine/xkb_manager.py
@@ -1,3 +1,4 @@
+import re
 import sys
 import traceback
 from os import environ
@@ -230,7 +231,7 @@ def is_new_symbol_mark(line: str) -> Optional[str]:
 
 
 def update_symbols_locale(path: Path, named_layouts: Variant) -> None:
-    """Update Kalamine layouts in an xkb/symbols file."""
+    """Update Kalamine layouts in an xkb/symbols/[locale] file."""
 
     text = ""
     modified_text = False
@@ -273,7 +274,12 @@ def update_symbols_locale(path: Path, named_layouts: Variant) -> None:
                 mark = get_symbol_mark(name)
                 symbols.write("\n")
                 symbols.write(mark["begin"])
-                symbols.write(layout.xkb_patch.rstrip() + "\n")
+                symbols.write(
+                    re.sub(  # drop lines starting with '//#'
+                        r"^//#.*\n", "", layout.xkb_symbols, flags=re.MULTILINE
+                    ).rstrip()
+                    + "\n"
+                )
                 symbols.write(mark["end"])
 
         symbols.close()

--- a/tests/test_serializer_xkb.py
+++ b/tests/test_serializer_xkb.py
@@ -178,52 +178,52 @@ def test_prog():
     expected = split(
         """
         // Digits
-        key <AE01> {[ 1               , exclam          , exclam          , VoidSymbol      ]}; // 1 !     !
-        key <AE02> {[ 2               , at              , parenleft       , VoidSymbol      ]}; // 2 @     (
-        key <AE03> {[ 3               , numbersign      , parenright      , VoidSymbol      ]}; // 3 #     )
-        key <AE04> {[ 4               , dollar          , apostrophe      , VoidSymbol      ]}; // 4 $     '
-        key <AE05> {[ 5               , percent         , quotedbl        , VoidSymbol      ]}; // 5 %     "
-        key <AE06> {[ 6               , asciicircum     , dead_circumflex , VoidSymbol      ]}; // 6 ^     ^
-        key <AE07> {[ 7               , ampersand       , 7               , VoidSymbol      ]}; // 7 &     7
-        key <AE08> {[ 8               , asterisk        , 8               , VoidSymbol      ]}; // 8 *     8
-        key <AE09> {[ 9               , parenleft       , 9               , VoidSymbol      ]}; // 9 (     9
-        key <AE10> {[ 0               , parenright      , slash           , VoidSymbol      ]}; // 0 )     /
+        key <AE01> {[ 1               , exclam          , exclam          , VoidSymbol      ]}; // 1 ! !
+        key <AE02> {[ 2               , at              , parenleft       , VoidSymbol      ]}; // 2 @ (
+        key <AE03> {[ 3               , numbersign      , parenright      , VoidSymbol      ]}; // 3 # )
+        key <AE04> {[ 4               , dollar          , apostrophe      , VoidSymbol      ]}; // 4 $ '
+        key <AE05> {[ 5               , percent         , quotedbl        , VoidSymbol      ]}; // 5 % "
+        key <AE06> {[ 6               , asciicircum     , dead_circumflex , VoidSymbol      ]}; // 6 ^ ^
+        key <AE07> {[ 7               , ampersand       , 7               , VoidSymbol      ]}; // 7 & 7
+        key <AE08> {[ 8               , asterisk        , 8               , VoidSymbol      ]}; // 8 * 8
+        key <AE09> {[ 9               , parenleft       , 9               , VoidSymbol      ]}; // 9 ( 9
+        key <AE10> {[ 0               , parenright      , slash           , VoidSymbol      ]}; // 0 ) /
 
         // Letters, first row
-        key <AD01> {[ q               , Q               , equal           , VoidSymbol      ]}; // q Q     =
-        key <AD02> {[ w               , W               , less            , lessthanequal   ]}; // w W     < ≤
-        key <AD03> {[ e               , E               , greater         , greaterthanequal]}; // e E     > ≥
-        key <AD04> {[ r               , R               , minus           , VoidSymbol      ]}; // r R     -
-        key <AD05> {[ t               , T               , plus            , VoidSymbol      ]}; // t T     +
+        key <AD01> {[ q               , Q               , equal           , VoidSymbol      ]}; // q Q =
+        key <AD02> {[ w               , W               , less            , lessthanequal   ]}; // w W < ≤
+        key <AD03> {[ e               , E               , greater         , greaterthanequal]}; // e E > ≥
+        key <AD04> {[ r               , R               , minus           , VoidSymbol      ]}; // r R -
+        key <AD05> {[ t               , T               , plus            , VoidSymbol      ]}; // t T +
         key <AD06> {[ y               , Y               , VoidSymbol      , VoidSymbol      ]}; // y Y
-        key <AD07> {[ u               , U               , 4               , VoidSymbol      ]}; // u U     4
-        key <AD08> {[ i               , I               , 5               , VoidSymbol      ]}; // i I     5
-        key <AD09> {[ o               , O               , 6               , VoidSymbol      ]}; // o O     6
-        key <AD10> {[ p               , P               , asterisk        , VoidSymbol      ]}; // p P     *
+        key <AD07> {[ u               , U               , 4               , VoidSymbol      ]}; // u U 4
+        key <AD08> {[ i               , I               , 5               , VoidSymbol      ]}; // i I 5
+        key <AD09> {[ o               , O               , 6               , VoidSymbol      ]}; // o O 6
+        key <AD10> {[ p               , P               , asterisk        , VoidSymbol      ]}; // p P *
 
         // Letters, second row
-        key <AC01> {[ a               , A               , braceleft       , VoidSymbol      ]}; // a A     {
-        key <AC02> {[ s               , S               , bracketleft     , VoidSymbol      ]}; // s S     [
-        key <AC03> {[ d               , D               , bracketright    , VoidSymbol      ]}; // d D     ]
-        key <AC04> {[ f               , F               , braceright      , VoidSymbol      ]}; // f F     }
-        key <AC05> {[ g               , G               , slash           , VoidSymbol      ]}; // g G     /
+        key <AC01> {[ a               , A               , braceleft       , VoidSymbol      ]}; // a A {
+        key <AC02> {[ s               , S               , bracketleft     , VoidSymbol      ]}; // s S [
+        key <AC03> {[ d               , D               , bracketright    , VoidSymbol      ]}; // d D ]
+        key <AC04> {[ f               , F               , braceright      , VoidSymbol      ]}; // f F }
+        key <AC05> {[ g               , G               , slash           , VoidSymbol      ]}; // g G /
         key <AC06> {[ h               , H               , VoidSymbol      , VoidSymbol      ]}; // h H
-        key <AC07> {[ j               , J               , 1               , VoidSymbol      ]}; // j J     1
-        key <AC08> {[ k               , K               , 2               , VoidSymbol      ]}; // k K     2
-        key <AC09> {[ l               , L               , 3               , VoidSymbol      ]}; // l L     3
-        key <AC10> {[ semicolon       , colon           , minus           , VoidSymbol      ]}; // ; :     -
+        key <AC07> {[ j               , J               , 1               , VoidSymbol      ]}; // j J 1
+        key <AC08> {[ k               , K               , 2               , VoidSymbol      ]}; // k K 2
+        key <AC09> {[ l               , L               , 3               , VoidSymbol      ]}; // l L 3
+        key <AC10> {[ semicolon       , colon           , minus           , VoidSymbol      ]}; // ; : -
 
         // Letters, third row
-        key <AB01> {[ z               , Z               , asciitilde      , VoidSymbol      ]}; // z Z     ~
-        key <AB02> {[ x               , X               , grave           , VoidSymbol      ]}; // x X     `
-        key <AB03> {[ c               , C               , bar             , brokenbar       ]}; // c C     | ¦
-        key <AB04> {[ v               , V               , underscore      , VoidSymbol      ]}; // v V     _
-        key <AB05> {[ b               , B               , backslash       , VoidSymbol      ]}; // b B     \\ 
+        key <AB01> {[ z               , Z               , asciitilde      , VoidSymbol      ]}; // z Z ~
+        key <AB02> {[ x               , X               , grave           , VoidSymbol      ]}; // x X `
+        key <AB03> {[ c               , C               , bar             , brokenbar       ]}; // c C | ¦
+        key <AB04> {[ v               , V               , underscore      , VoidSymbol      ]}; // v V _
+        key <AB05> {[ b               , B               , backslash       , VoidSymbol      ]}; // b B \\ 
         key <AB06> {[ n               , N               , VoidSymbol      , VoidSymbol      ]}; // n N
-        key <AB07> {[ m               , M               , 0               , VoidSymbol      ]}; // m M     0
-        key <AB08> {[ comma           , less            , comma           , VoidSymbol      ]}; // , <     ,
-        key <AB09> {[ period          , greater         , period          , VoidSymbol      ]}; // . >     .
-        key <AB10> {[ slash           , question        , plus            , VoidSymbol      ]}; // / ?     +
+        key <AB07> {[ m               , M               , 0               , VoidSymbol      ]}; // m M 0
+        key <AB08> {[ comma           , less            , comma           , VoidSymbol      ]}; // , < ,
+        key <AB09> {[ period          , greater         , period          , VoidSymbol      ]}; // . > .
+        key <AB10> {[ slash           , question        , plus            , VoidSymbol      ]}; // / ? +
 
         // Pinky keys
         key <AE11> {[ minus           , underscore      , VoidSymbol      , VoidSymbol      ]}; // - _
@@ -231,14 +231,14 @@ def test_prog():
         key <AE13> {[ VoidSymbol      , VoidSymbol      , VoidSymbol      , VoidSymbol      ]}; //
         key <AD11> {[ bracketleft     , braceleft       , VoidSymbol      , VoidSymbol      ]}; // [ {
         key <AD12> {[ bracketright    , braceright      , VoidSymbol      , VoidSymbol      ]}; // ] }
-        key <AC11> {[ apostrophe      , quotedbl        , dead_acute      , dead_diaeresis  ]}; // ' "     ´ ¨
+        key <AC11> {[ apostrophe      , quotedbl        , dead_acute      , dead_diaeresis  ]}; // ' " ´ ¨
         key <AB11> {[ VoidSymbol      , VoidSymbol      , VoidSymbol      , VoidSymbol      ]}; //
-        key <TLDE> {[ grave           , asciitilde      , dead_grave      , dead_tilde      ]}; // ` ~     ` ~
+        key <TLDE> {[ grave           , asciitilde      , dead_grave      , dead_tilde      ]}; // ` ~ ` ~
         key <BKSL> {[ backslash       , bar             , VoidSymbol      , VoidSymbol      ]}; // \\ |
         key <LSGT> {[ VoidSymbol      , VoidSymbol      , VoidSymbol      , VoidSymbol      ]}; //
 
         // Space bar
-        key <SPCE> {[ space           , space           , space           , space           ]}; //     ' '
+        key <SPCE> {[ space           , space           , space           , space           ]}; //
         """
     )
 


### PR DESCRIPTION
fixes #97 and outputs less ambiguous xkb files (hopefully):

- the `.xkb_keymap` file (formerly `*.xkb`) is a full, standalone file, to be used with `xkbcomp`
- the `.xkb_symbols` file (formerly `*.xkb_custom`) is meant to be put in `xkb/symbols/custom` 

Both files now have a header that should give clear explanations on their purpose.