### PR TITLE
fix: more error checking

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -56,6 +56,7 @@ jobs:
           pytest
 
       - name: Run black
+        run: black kalamine --diff
         run: black kalamine --check
 
       - name: Run isort

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 all: format lint test
 
 dev:  ## Install a development environment
-	python3 -m pip install --user .[dev]
+	python3 -m pip install --user --upgrade .[dev]
 	# python3 -m pip install --user --upgrade build
 	# python3 -m pip install --user --upgrade twine wheel
 

--- a/kalamine/msklc_manager.py
+++ b/kalamine/msklc_manager.py
@@ -89,7 +89,7 @@ class MsklcManager:
         # The file must have a correct name to be reflected in the installer.
         dummy_klc = self._create_dummy_layout()
         klc_file = Path(self._working_dir) / Path(f'{self._layout.meta["name8"]}.klc')
-        with klc_file.open("w", encoding="utf-16le", newline="\n") as file:
+        with klc_file.open("w", encoding="utf-16le", newline="\r\n") as file:
             file.write(dummy_klc)
         msklc = self._msklc_dir / Path("MSKLC.exe")
         result = subprocess.run(
@@ -141,7 +141,7 @@ class MsklcManager:
         klc_file = self._working_dir / Path(f"{name8}.klc")
 
         # create correct klc
-        with klc_file.open("w", encoding="utf-16le", newline="\n") as file:
+        with klc_file.open("w", encoding="utf-16le", newline="\r\n") as file:
             try:
                 file.write(self._layout.klc)
             except ValueError as err:
@@ -150,10 +150,10 @@ class MsklcManager:
 
         self.create_c_files()
         c_file = klc_file.with_suffix(".RC")
-        with c_file.open("w", encoding="utf-16le", newline="\n") as file:
+        with c_file.open("w", encoding="utf-16le", newline="\r\n") as file:
             file.write(self._layout.klc_rc)
         c_file = klc_file.with_suffix(".C")
-        with c_file.open("w", encoding="utf-16le", newline="\n") as file:
+        with c_file.open("w", encoding="utf-16le", newline="\r\n") as file:
             file.write(self._layout.klc_c)
         c_files = [".C", ".RC", ".H", ".DEF"]
 

--- a/kalamine/msklc_manager.py
+++ b/kalamine/msklc_manager.py
@@ -89,7 +89,7 @@ class MsklcManager:
         # The file must have a correct name to be reflected in the installer.
         dummy_klc = self._create_dummy_layout()
         klc_file = Path(self._working_dir) / Path(f'{self._layout.meta["name8"]}.klc')
-        with klc_file.open("w", encoding="utf-16le", newline="\r\n") as file:
+        with klc_file.open("w", encoding="utf-16le", newline="\n") as file:
             file.write(dummy_klc)
         msklc = self._msklc_dir / Path("MSKLC.exe")
         result = subprocess.run(
@@ -141,7 +141,7 @@ class MsklcManager:
         klc_file = self._working_dir / Path(f"{name8}.klc")
 
         # create correct klc
-        with klc_file.open("w", encoding="utf-16le", newline="\r\n") as file:
+        with klc_file.open("w", encoding="utf-16le", newline="\n") as file:
             try:
                 file.write(self._layout.klc)
             except ValueError as err:
@@ -150,10 +150,10 @@ class MsklcManager:
 
         self.create_c_files()
         c_file = klc_file.with_suffix(".RC")
-        with c_file.open("w", encoding="utf-16le", newline="\r\n") as file:
+        with c_file.open("w", encoding="utf-16le", newline="\n") as file:
             file.write(self._layout.klc_rc)
         c_file = klc_file.with_suffix(".C")
-        with c_file.open("w", encoding="utf-16le", newline="\r\n") as file:
+        with c_file.open("w", encoding="utf-16le", newline="\n") as file:
             file.write(self._layout.klc_c)
         c_files = [".C", ".RC", ".H", ".DEF"]
 
@@ -172,10 +172,22 @@ class MsklcManager:
             ("-i", "ia64"),
             ("-o", "wow64"),
         ]:
-            subprocess.run(
-                [kbdutools, "-u", arch_flag, klc_file], capture_output=not self._verbose
-            ).check_returncode()
-            move(str(dll), str(INST_DIR / Path(arch)))
+            result = subprocess.run(
+                [kbdutools, "-u", arch_flag, klc_file],
+                text=True,
+                capture_output=not self._verbose,
+            )
+            if result.returncode == 0:
+                move(str(dll), str(INST_DIR / Path(arch)))
+            else:
+                # Restore write permission
+                for suffix in c_files:
+                    os.chmod(klc_file.with_suffix(suffix), S_IWUSR)
+
+                print(f"Error while creating DLL for arch {arch}:")
+                print(result.stdout)
+                print(result.stderr)
+                return False
 
         # Restore write permission
         for suffix in c_files:


### PR DESCRIPTION
Catch errors on generating DLLs instead of panicking.
Restore write permission on C files on error to avoid permission denied error on next run
Revert back to `\n` line separator because I don’t know why, but on my system, `\r\n` ends into `\r` only in the file and rejected by `kbdutools`