### PR TITLE
Handle and document all geometries from YAML

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -83,7 +83,7 @@ Dead keys are preceded by a `*` sign. They can be used in the `base` layer:
 
                    +-----+
     shift = " ---> | "*" | <----- altgr+shift+key = dead diaeresis
-    base = ' ----> | '*' | <----- altgt+key       = dead acute accent
+    base = ' ----> | '*' | <----- altgr+key       = dead acute accent
                    +-----+
 
 

--- a/kalamine/cli.py
+++ b/kalamine/cli.py
@@ -9,7 +9,7 @@ import click
 
 from .generators import ahk, keylayout, klc, web, xkb
 from .help import create_layout, user_guide
-from .layout import KeyboardLayout, load_layout
+from .layout import GEOMETRY_NAMES, KeyboardLayout, load_layout
 from .server import keyboard_server
 
 
@@ -162,12 +162,25 @@ def build(
         click.echo(f"... {output_file}")
 
 
-# TODO: Provide geometry choices
 @cli.command()
 @click.argument("output_file", nargs=1, type=click.Path(exists=False, path_type=Path))
-@click.option("--geometry", default="ISO", help="Specify keyboard geometry.")
-@click.option("--altgr/--no-altgr", default=False, help="Set an AltGr layer.")
-@click.option("--1dk/--no-1dk", "odk", default=False, help="Set a custom dead key.")
+@click.option(
+    "--geometry",
+    default="ISO",
+    type=click.Choice(GEOMETRY_NAMES, case_sensitive=False),
+    help="Specify keyboard geometry (defaults to ISO).",
+)
+@click.option(
+    "--altgr/--no-altgr",
+    default=False,
+    help="Set an AltGr layer (defaults to --no-altgr).",
+)
+@click.option(
+    "--1dk/--no-1dk",
+    "odk",
+    default=False,
+    help="Set a custom dead key (defaults to --no-1dk).",
+)
 def new(output_file: Path, geometry: str, altgr: bool, odk: bool) -> None:
     """Create a new TOML layout description."""
     create_layout(output_file, geometry, altgr, odk)

--- a/kalamine/data/user_guide.yaml
+++ b/kalamine/data/user_guide.yaml
@@ -44,7 +44,7 @@ Dead_Keys:
 
                            +-----+
             shift = " ---> | "*" | <----- altgr+shift+key = dead diaeresis
-            base = ' ----> | '*' | <----- altgt+key       = dead acute accent
+            base = ' ----> | '*' | <----- altgr+key       = dead acute accent
                            +-----+
 
     Standard_Dead_Keys: |

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -121,6 +121,8 @@ GEOMETRY = {
     key: GeometryDescr.from_dict(val) for key, val in load_data("geometry").items()
 }
 
+GEOMETRY_NAMES = list(map(str, GEOMETRY.keys()))
+
 
 ###
 # Main
@@ -375,14 +377,15 @@ class KeyboardLayout:
 
     @property
     def geometry(self) -> str:
-        """ANSI, ISO, ERGO."""
+        """ANSI, ISO, ABNT, JIS, ALT, ERGO."""
         return self.meta["geometry"].upper()
 
     @geometry.setter
     def geometry(self, value: str) -> None:
-        """ANSI, ISO, ERGO."""
+        """ANSI, ISO, ABNT, JIS, ALT, ERGO."""
         shape = value.upper()
-        if shape not in ["ANSI", "ISO", "ERGO"]:
+        if shape not in GEOMETRY_NAMES:
+            click.echo(f"Unsupported geometry '{shape}', falling back to 'ISO'")
             shape = "ISO"
         self.meta["geometry"] = shape
 

--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -75,7 +75,7 @@ class MetaDescr:
 class SpacebarDescr:
     shift:       str = " "
     altgr:       str = " "
-    altgt_shift: str = " "
+    altgr_shift: str = " "
     odk:         str = "'"
     odk_shift:   str = "'"
 # fmt: on


### PR DESCRIPTION
Hi,

Many thanks for this great project!

I had been maintaining my custom XKB symbols by hand until now, I'm grateful that I can now rely on a tool that translates a human-readable format into XKB.

This PR exposes in the CLI help the list of available geometries.
The help now looks like this:
```console
$ python -m kalamine.cli new --help
Usage: python -m kalamine.cli new [OPTIONS] OUTPUT_FILE

  Create a new TOML layout description.

Options:
  --geometry [ANSI|ISO|ABNT|JIS|ALT|ERGO]
                                  Specify keyboard geometry (defaults to ISO).
  --altgr / --no-altgr            Set an AltGr layer (defaults to --no-altgr).
  --1dk / --no-1dk                Set a custom dead key (defaults to
                                  --no-1dk).
  --help                          Show this message and exit.
```

Also, before the PR, if you passed a geometry such as `JIS`, it was silently ignored and changed to `ISO`. The input geometry is now checked against the same list of geometries implemented in the YAML, and so all declared geometries are effectively supported.

Finally, the PR includes a minor `altgt` → `altgr` fix.