### PR TITLE
Feat: Builds even if version number is too short (i.e. not x.y.z format)

### DIFF
--- a/kalamine/layout.py
+++ b/kalamine/layout.py
@@ -43,6 +43,17 @@ def load_layout(layout_path: Path) -> Dict:
             ext = load_descriptor(parent_path)
             ext.update(cfg)
             cfg = ext
+        if "version" in cfg:
+            version_check = cfg["version"].split(".")
+            if len(version_check) > 3:
+                raise Exception(
+                    f"Layout version number **must** follow `x.y.z` format\nCurrently got `version={cfg['version']}`"
+                )
+            missing_digits = (3 - len(version_check)) * ["0"]
+            cfg["version"] = ".".join(version_check + missing_digits)
+        else:
+            cfg["version"] = MetaDescr.version
+
         return cfg
 
     except Exception as exc:


### PR DESCRIPTION
Closes #144 by adding the required number of ".0" to match x.y.z format. instead of exiting, kalamine now replaces the version number such as:
   1 → 1.0.0
 1.2 → 1.2.0
if no version is provided, default value will be used