### PR TITLE
fix(klc): avoid empty keys

### DIFF
--- a/kalamine/generators/klc.py
+++ b/kalamine/generators/klc.py
@@ -81,6 +81,8 @@ def klc_virtual_key(layout: "KeyboardLayout", symbols: list, scan_code: str) -> 
         return "OEM_MINUS"
     elif base == " ":
         return "SPACE"
+    elif base == "-1" and shifted == "-1":
+        raise Exception("Empty key are not allowed, please complete the description")
     else:
         MAX_OEM = 9
         # We affect abitrary OEM VK and it will not match the one


### PR DESCRIPTION
This avoid "Too many OEM" because of empty keys. Now we exit if such a key is detected